### PR TITLE
🙈 Ignores Next.js type generation file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dist
 .pnp.*
 
 .DS_Store
+next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "stylelint": "stylelint '**/*.css' --cache",
-    "test": "npm run prettier:check && npm run lint && npm run typecheck && npm run jest",
+    "test": "npx next typegen && npm run prettier:check && npm run lint && npm run typecheck && npm run jest",
     "typecheck": "tsc --noEmit"
   },
   "version": "3.0.0"


### PR DESCRIPTION
Adds next-env.d.ts to .gitignore and removes it from version control since it's an auto-generated file that shouldn't be committed.

Updates test script to regenerate Next.js types before running tests to ensure type definitions are always current in the development environment.