### PR TITLE
🔧 chore: Update dependencies and fix iframe tag

### DIFF
--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -82,7 +82,7 @@ export function Welcome() {
         height="225"
         width="100%"
         style={{ border: 'none', borderRadius: 8 }}
-      ></iframe>
+      />
     </>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "@gfazioli/mantine-marquee": "^2.6.9",
-    "@gfazioli/mantine-text-animate": "^2.3.9",
-    "@mantine/core": "8.3.10",
-    "@mantine/hooks": "8.3.10",
+    "@gfazioli/mantine-marquee": "^2.6.10",
+    "@gfazioli/mantine-text-animate": "^2.3.10",
+    "@mantine/core": "8.3.11",
+    "@mantine/hooks": "8.3.11",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/bundle-analyzer": "^16.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3013,27 +3013,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gfazioli/mantine-marquee@npm:^2.6.9":
-  version: 2.6.9
-  resolution: "@gfazioli/mantine-marquee@npm:2.6.9"
+"@gfazioli/mantine-marquee@npm:^2.6.10":
+  version: 2.6.10
+  resolution: "@gfazioli/mantine-marquee@npm:2.6.10"
   peerDependencies:
     "@mantine/core": ">=7.0.0"
     "@mantine/hooks": ">=7.0.0"
     react: ^18.x || ^19.x
     react-dom: ^18.x || ^19.x
-  checksum: 10c0/28ced0c98d5cc325e8014046ac64e48abba8b75cbe825b4d666d8e7e233f6ebbbeacf7e1c1561b8a544ee5bb2b39ecc5b3270d056258c7d6c1f8c728079e9527
+  checksum: 10c0/72ff7c2dcea56924d4dfe79ad36e86271141174e9b2e4b62bff8e807728a6619a5cfd407ac789785dbd1bf6af621464ea4ae6bef2586b032c977c140d018a6de
   languageName: node
   linkType: hard
 
-"@gfazioli/mantine-text-animate@npm:^2.3.9":
-  version: 2.3.9
-  resolution: "@gfazioli/mantine-text-animate@npm:2.3.9"
+"@gfazioli/mantine-text-animate@npm:^2.3.10":
+  version: 2.3.10
+  resolution: "@gfazioli/mantine-text-animate@npm:2.3.10"
   peerDependencies:
     "@mantine/core": ">=7.0.0"
     "@mantine/hooks": ">=7.0.0"
     react: ^18.x || ^19.x
     react-dom: ^18.x || ^19.x
-  checksum: 10c0/75fd0c50f89b578bd66ff86c6e55807b80d42449758f04d643ecdc23f5c7ca4f98bc70d07e7f9909b409848a7e7d989e626668617fbaadade21774197872431c
+  checksum: 10c0/f20a9c03adde9642d4cb784437a35ba56ef0ff664290416dddd12eb048fb1754e42045d55d8e2dcf0e2705ff10f953770a4edf67970f75a842349541b10e8840
   languageName: node
   linkType: hard
 
@@ -3839,9 +3839,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mantine/core@npm:8.3.10":
-  version: 8.3.10
-  resolution: "@mantine/core@npm:8.3.10"
+"@mantine/core@npm:8.3.11":
+  version: 8.3.11
+  resolution: "@mantine/core@npm:8.3.11"
   dependencies:
     "@floating-ui/react": "npm:^0.27.16"
     clsx: "npm:^2.1.1"
@@ -3850,19 +3850,19 @@ __metadata:
     react-textarea-autosize: "npm:8.5.9"
     type-fest: "npm:^4.41.0"
   peerDependencies:
-    "@mantine/hooks": 8.3.10
+    "@mantine/hooks": 8.3.11
     react: ^18.x || ^19.x
     react-dom: ^18.x || ^19.x
-  checksum: 10c0/d629088471dafb19c2a61e6e8ff47eff6c818f8cf8a1f795110126d86f8bc93c670039127c108f21b02c8bb8ee6e65fbd57d51f52fe86da816fc83c8468ac4c3
+  checksum: 10c0/09942a37b77626f197bc8b302da5473d82694a26ed345c62811134af174095e80548a35201fd4c0ad67d7ea48c90c2585b7bda9d8dab69a9a9fa2a3ec735b320
   languageName: node
   linkType: hard
 
-"@mantine/hooks@npm:8.3.10":
-  version: 8.3.10
-  resolution: "@mantine/hooks@npm:8.3.10"
+"@mantine/hooks@npm:8.3.11":
+  version: 8.3.11
+  resolution: "@mantine/hooks@npm:8.3.11"
   peerDependencies:
     react: ^18.x || ^19.x
-  checksum: 10c0/4957483d4ebefcc0e745a0aebf22f74d96a9fb0472cde373e9e37adf866a8ba3deb1665fe4ccd5831eb32bac0560cf1d70ef821b448c0cfd44bceab09f219056
+  checksum: 10c0/7256b04df9ab8750d45a1c74f25b32763a4ca043ba777908f5869250792eaded395ce00d54455637cbaad0d2c7c20f224e5d40772d8605c811b5c381e4bf4da6
   languageName: node
   linkType: hard
 
@@ -13464,11 +13464,11 @@ __metadata:
     "@babel/core": "npm:^7.28.5"
     "@eslint/eslintrc": "npm:^3.3.3"
     "@eslint/js": "npm:^9.39.2"
-    "@gfazioli/mantine-marquee": "npm:^2.6.9"
-    "@gfazioli/mantine-text-animate": "npm:^2.3.9"
+    "@gfazioli/mantine-marquee": "npm:^2.6.10"
+    "@gfazioli/mantine-text-animate": "npm:^2.3.10"
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.7.0"
-    "@mantine/core": "npm:8.3.10"
-    "@mantine/hooks": "npm:8.3.10"
+    "@mantine/core": "npm:8.3.11"
+    "@mantine/hooks": "npm:8.3.11"
     "@mdx-js/loader": "npm:^3.1.1"
     "@mdx-js/react": "npm:^3.1.1"
     "@next/bundle-analyzer": "npm:^16.1.1"


### PR DESCRIPTION
- Bump mantine-marquee, mantine-text-animate, mantine/core, mantine/hooks to latest patch versions
- Convert iframe to self‑closing tag for cleaner JSX
- Keeps component rendering correct and dependencies up to date.
