### PR TITLE
♻️ refactor(styles): clean up CSS imports and enforce order close #18

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,7 @@
 import '@mantine/core/styles.css';
+// !! The order of these imports is important !!
+import '@gfazioli/mantine-marquee/styles.css';
+import '@gfazioli/mantine-text-animate/styles.css';
 
 import { ColorSchemeScript, MantineProvider } from '@mantine/core';
 import { theme } from '../theme';

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,14 @@
-import '@gfazioli/mantine-marquee/styles.layer.css';
-import '@gfazioli/mantine-text-animate/styles.layer.css';
-import '@mantine/core/styles.layer.css';
+import '@mantine/core/styles.css';
+// !! The order of these imports is important !!
+import '@gfazioli/mantine-marquee/styles.css';
+import '@gfazioli/mantine-text-animate/styles.css';
 
 import { Layout } from 'nextra-theme-docs';
 import { Banner, Head } from 'nextra/components';
 import { getPageMap } from 'nextra/page-map';
 import { ColorSchemeScript, mantineHtmlProps, MantineProvider } from '@mantine/core';
+// !! End of important imports !!
+
 import { MantineFooter, MantineNavBar } from '@/components';
 import config from '@/config';
 import pack from '../package.json';

--- a/components/Content/Content.story.tsx
+++ b/components/Content/Content.story.tsx
@@ -1,5 +1,3 @@
-import '@gfazioli/mantine-marquee/styles.layer.css';
-
 import { Content } from './Content';
 
 export default {

--- a/components/FileTreeLabel/FileTreeLabel.tsx
+++ b/components/FileTreeLabel/FileTreeLabel.tsx
@@ -4,8 +4,6 @@ import React from 'react';
 import { IconCornerRightDown } from '@tabler/icons-react';
 import { Anchor, Code, Group } from '@mantine/core';
 
-import '@mantine/core/styles.css';
-
 type FileTreeLabelProps = {
   name: string;
   type: 'folder' | 'file';


### PR DESCRIPTION
- Replace legacy `.layer.css` imports with standard `.css` for Mantine and custom components.
- Add comments to highlight the importance of import order in Storybook and app layout.
- Remove unused imports from story and component files.
- Ensure consistent styling across the project and Storybook.
