### PR TITLE
🐛 fix(release-notes): resilient GitHub API fetch

### DIFF
--- a/app/api/github-releases/route.ts
+++ b/app/api/github-releases/route.ts
@@ -14,19 +14,45 @@ export async function GET(request: Request) {
       return Response.json({ error: 'Bots are not allowed' }, { status: 403 });
     }
 
-    const response = await fetch(
-      `${config.gitHub.releasesUrl}?per_page=${config.releaseNotes.maxReleases}`,
-      {
-        headers: {
-          Accept: 'application/vnd.github+json',
-          // Authorization: `Bearer ${process.env.GITHUB_TOKEN}`, // Optional for rate limit
-        },
+    const url = `${config.gitHub.releasesUrl}?per_page=${config.releaseNotes.maxReleases}`;
+    const baseHeaders: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      // GitHub requires a User-Agent on unauthenticated requests.
+      'User-Agent': config.gitHub.repo,
+    };
+
+    // Try authenticated first if a token is configured (5000 req/hour vs 60/hour).
+    // If the token is rejected (401 invalid/expired, 403 blocked by org policy
+    // like fine-grained PATs with lifetime > 366 days), retry unauthenticated —
+    // public releases are readable without auth.
+    let response: Response;
+    if (process.env.GITHUB_TOKEN) {
+      response = await fetch(url, {
+        headers: { ...baseHeaders, Authorization: `Bearer ${process.env.GITHUB_TOKEN}` },
+      });
+      if (response.status === 401 || response.status === 403) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `GITHUB_TOKEN returned ${response.status} — falling back to unauthenticated fetch`
+        );
+        response = await fetch(url, { headers: baseHeaders });
       }
-    );
+    } else {
+      response = await fetch(url, { headers: baseHeaders });
+    }
 
     if (!response.ok) {
+      const bodyText = await response.text();
+      const rateRemaining = response.headers.get('x-ratelimit-remaining');
+      const rateReset = response.headers.get('x-ratelimit-reset');
       // eslint-disable-next-line no-console
-      console.error('Error fetching releases:', response.statusText);
+      console.error('[github-releases] non-OK response', {
+        status: response.status,
+        statusText: response.statusText,
+        rateRemaining,
+        rateReset,
+        body: bodyText.slice(0, 300),
+      });
       return Response.json(response.statusText, { status: response.status });
     }
 

--- a/components/ReleaseNotes/use-release-notes.ts
+++ b/components/ReleaseNotes/use-release-notes.ts
@@ -72,6 +72,11 @@ export function useReleaseNotes() {
         return;
       }
 
+      if (!data.releases || !Array.isArray(data.releases)) {
+        setError('Unexpected response from /api/github-releases. Check the server logs.');
+        return;
+      }
+
       const fetchReleases = async () => {
         const releases = await Promise.all(
           data.releases.map(async (release) => ({


### PR DESCRIPTION
## Problem

The `/api/github-releases` route currently runs unauthenticated (Authorization header is commented out). Sites generated from this template that want to enable a `GITHUB_TOKEN` for the 5000 req/hour quota hit two stacked bugs:

1. Uncommenting the Authorization line as-is sends `Bearer undefined` when the env var is missing, returning 401.
2. If the token is a fine-grained PAT rejected by an org policy (e.g. `wpbones` forbids lifetime > 366 days), GitHub returns 403. The code had no fallback for 401 or 403, so the UI got stuck forever on "Loading releases…".
3. On the client, `data.releases.map()` crashed with `Cannot read properties of undefined` when the API returned a plain string body like `"Forbidden"`.

## Fix

`app/api/github-releases/route.ts`:
- Attach `Authorization` header only when `process.env.GITHUB_TOKEN` is truthy.
- On `401` or `403` from an authenticated request, retry unauthenticated (public releases don't need auth).
- Send a proper `User-Agent` derived from `config.gitHub.repo` (GitHub requires it on unauth requests).
- Log full error body + `x-ratelimit-*` headers on non-OK responses — makes future token/quota issues diagnosable from server logs.

`components/ReleaseNotes/use-release-notes.ts`:
- Guard against non-array `data.releases` — surface a clear error in the UI instead of crashing silently.

## Downstream

This template generated all my docs sites (wpbones.com, findergit-website, scotty-plugin-website, bannerize-website, and others). The same bug surfaced on wpbones.com, fixed there in [wpbones/website-docs#27](https://github.com/wpbones/website-docs/pull/27). Backporting to the template so future generations are resilient by default.