### PR TITLE
chore(deps): upgrade @gfazioli/mantine-border-animate to v3

### DIFF
--- a/components/Content/Content.tsx
+++ b/components/Content/Content.tsx
@@ -60,7 +60,7 @@ export const Content = () => {
           title="Mantine Extensions Hub"
           description="Browse 25+ Mantine UI extensions — split panes, onboarding tours, players, parallax and more — ready to drop into this template."
           beamProps={{
-            beamMode: 'path',
+            beamMode: 'dot',
             colorFrom: 'cyan',
             colorTo: 'indigo',
             size: 'lg',
@@ -73,10 +73,10 @@ export const Content = () => {
           title="Fumadocs template"
           description="Prefer Fumadocs? The same starter with fumadocs-core under the hood and a docs UI built 100% with Mantine."
           beamProps={{
-            beamMode: 'conic',
+            beamMode: 'wedge',
             colorFrom: 'pink',
             colorTo: 'grape',
-            size: 'md',
+            spread: 72,
             duration: 8,
             reverse: true,
           }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@gfazioli/mantine-border-animate": "^2.0.9",
+    "@gfazioli/mantine-border-animate": "^3.0.1",
     "@gfazioli/mantine-marquee": "^4.1.5",
     "@gfazioli/mantine-text-animate": "^4.0.9",
     "@mantine/core": "9.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2319,16 +2319,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gfazioli/mantine-border-animate@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "@gfazioli/mantine-border-animate@npm:2.0.9"
+"@gfazioli/mantine-border-animate@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@gfazioli/mantine-border-animate@npm:3.0.1"
   peerDependencies:
     "@mantine/core": ">=9.0.0"
     "@mantine/hooks": ">=9.0.0"
     "@tabler/icons-react": ^3.34.0
     react: ^18.x || ^19.x
     react-dom: ^18.x || ^19.x
-  checksum: 10c0/2b5c471d135d33c673ef580f76e7f5779118af05612448587f5d3fb610980e297c9624334b5c39ca7b13e105dc9fcc62dcb85a3b2121369e52d86ee52ecb96eb
+  checksum: 10c0/b3cdb3ded987a1a410d69ced050206428fcd2d0f65a858809e34b5005ca249f11e5e13c668b01caa4b4bf394405470a72abaf225cbb464712e5b76ee2fb46c00
   languageName: node
   linkType: hard
 
@@ -11552,7 +11552,7 @@ __metadata:
   resolution: "mantine-next-nextra-template@workspace:."
   dependencies:
     "@babel/core": "npm:^7.29.7"
-    "@gfazioli/mantine-border-animate": "npm:^2.0.9"
+    "@gfazioli/mantine-border-animate": "npm:^3.0.1"
     "@gfazioli/mantine-marquee": "npm:^4.1.5"
     "@gfazioli/mantine-text-animate": "npm:^4.0.9"
     "@mantine/core": "npm:9.6.0"


### PR DESCRIPTION
## Summary

Upgrades `@gfazioli/mantine-border-animate` from `^2.0.9` to `^3.0.1` and migrates the two `EcosystemBox` beams in `components/Content/Content.tsx` to the v3 API. `--target minor` never crosses a major, so this repo had been left behind by the fleet-wide dependency rollouts.

## The three renames applied

| v2 | v3 | Note |
|---|---|---|
| `beamMode: "path"` | `beamMode: "dot"` | Same rendering; `size` still means the dot, so it is unchanged |
| `beamMode: "conic"` | `beamMode: "wedge"` | |
| `size: "md"` (conic) | `spread: 72` | `size` is now only the dot; the wedge width moved to `spread`, **in degrees** |

`spread: 72` is not a guess. v2 mapped `md` to `20` as a *percentage* of the circle (`getBeamSpread`) and then used `half = P / 2`. v3 takes real degrees and uses `half = D / 2 / 3.6`, so an identical `half` needs `D = 3.6 x P = 72`. That also reproduces the two endpoints the upgrade guide documents (`xs` = 18 deg, `xl` = 180 deg).

## Verified against the rendered CSS, not by eye

The border is animated, so comparing two screenshots taken at different instants proves nothing about the wedge width. The conic-gradient stop percentages were read out of the live page before and after:

| | before (2.0.9) | after (3.0.1) |
|---|---|---|
| dot box | `radial-gradient(#0c8599 0px, #3b5bdb 40%, transparent 70%)`, 320x320, blur 2px, 6s normal | identical |
| wedge box | stops at **40% / 45% / 55% / 60%**, 416x212.75, blur 2px, 8s reverse | **identical stops**, everything else identical |

Only the animation `from` angle differs, which is just where the loop happened to be at capture time.

This also proves v3 is the version actually running: with `size` removed from the wedge, v2 would have fallen back to its default `half = 5` and produced stops at 45 / 47.5 / 52.5 / 55 — a visibly narrower wedge. Zero console warnings, which confirms no v2 prop is left anywhere (v3 warns once per renamed prop in development).

The `delay={100}` elsewhere in `components/Welcome/Welcome.tsx` was checked and left alone: it belongs to `TextAnimate.Typewriter`, not to `BorderAnimate`.

## Test plan
- [x] `yarn test` passes
- [x] `yarn build` passes with `.next` removed first (the Turbopack FileSystem Cache does not invalidate on `node_modules`, so a build that keeps it can replay the previous version)
- [x] Rendered gradients compared before/after in a real browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated ecosystem card animations with refined beam effects for a smoother visual presentation.

* **Bug Fixes**
  * Improved compatibility and animation behavior through an updated visual-effects component library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->